### PR TITLE
Deep sleep between sends

### DIFF
--- a/Lora-TTNMapper-T-Beam.ino
+++ b/Lora-TTNMapper-T-Beam.ino
@@ -2,6 +2,8 @@
 #include <hal/hal.h>
 #include <WiFi.h>
 
+#include "esp_sleep.h"
+
 // UPDATE the config.h file in the same folder WITH YOUR TTN KEYS AND ADDR.
 #include "config.h"
 #include "gps.h"
@@ -78,7 +80,9 @@ void onEvent (ev_t ev) {
         Serial.println(s);
       }
       // Schedule next transmission
-      os_setTimedCallback(&sendjob, os_getTime() + sec2osticks(TX_INTERVAL), do_send);
+      esp_sleep_enable_timer_wakeup(TX_INTERVAL*1000000);
+      esp_deep_sleep_start();
+      do_send(&sendjob);
       break;
     case EV_LOST_TSYNC:
       Serial.println(F("EV_LOST_TSYNC"));

--- a/Lora-TTNMapper-T-Beam.ino
+++ b/Lora-TTNMapper-T-Beam.ino
@@ -25,7 +25,7 @@ void os_getDevKey (u1_t* buf) { }
 
 static osjob_t sendjob;
 // Schedule TX every this many seconds (might become longer due to duty cycle limitations).
-const unsigned TX_INTERVAL = 30;
+const unsigned TX_INTERVAL = 120;
 
 // Pin mapping
 const lmic_pinmap lmic_pins = {


### PR DESCRIPTION
Included esp_sleep.h and exhanged os_setTimedCallback for deep sleep with timer wakeup.
This causes the setup loop to run again upon awakening, but this was not a problem when i tested it.
I also changed the tx interval to 120, since this is the fair-use interval suggested by TTN. 